### PR TITLE
ISSUE-5: feat(api): support raw base64 return mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,23 @@ cd ios && pod install
 ## Features
 
 - **Image format conversion**
+
   - Converts local HEIC/HEIF images to JPEG.
   - JPEG and PNG inputs are passed through without conversion.
 
 - **EXIF metadata preservation**
+
   - Copies supported metadata such as GPS, camera, orientation, and date fields from the source image to the converted JPEG.
   - Exact metadata preservation depends on platform image/EXIF support.
 
 - **iOS and Android support**
+
   - iOS implementation: Objective-C++ using ImageIO/CoreImage.
   - Android implementation: Kotlin using `BitmapFactory` and AndroidX ExifInterface.
   - Supports React Native old architecture and TurboModule/new architecture wiring.
 
 - **Simple JavaScript API**
-  - One exported helper: `convertImage(imagePath)`.
+  - One exported helper: `convertImage(imagePath, options?)`.
 
 ## Usage
 
@@ -38,6 +41,12 @@ cd ios && pod install
 import { convertImage } from 'react-native-simple-heic2jpg';
 
 const result = await convertImage(path);
+```
+
+To receive raw base64 instead of a file URI:
+
+```js
+const base64 = await convertImage(path, { returnBase64: true });
 ```
 
 ### Input path contract
@@ -51,10 +60,19 @@ const result = await convertImage(path);
 
 ### Return value
 
-The JavaScript API always resolves to a `file://` URI string.
+By default, the JavaScript API resolves to a `file://` URI string.
 
 - HEIC/HEIF input: returns the converted JPEG file URI.
 - JPEG/PNG input: returns the original file URI.
+
+When `returnBase64` is `true`, the JavaScript API resolves to a raw base64 string.
+
+- HEIC/HEIF input: returns the converted JPEG bytes as base64.
+- JPEG/JPG/PNG input: returns the original file bytes as base64.
+- The returned string does not include a `file://` prefix.
+- The returned string does not include a `data:image/...;base64,` prefix. Add one in your app if your target component requires a data URI.
+- HEIC/HEIF base64 mode may use temporary/cache files internally so the returned base64 comes from finalized JPEG bytes with preserved metadata. Generated temporary/cache files are cleaned after encoding.
+- Base64 increases memory usage compared with URI mode, so URI mode remains the default and is recommended for large images.
 
 ## License
 

--- a/android/generated/java/com/simpleheic2jpg/NativeSimpleHeic2jpgSpec.java
+++ b/android/generated/java/com/simpleheic2jpg/NativeSimpleHeic2jpgSpec.java
@@ -35,4 +35,8 @@ public abstract class NativeSimpleHeic2jpgSpec extends ReactContextBaseJavaModul
   @ReactMethod
   @DoNotStrip
   public abstract void convertImageAtPath(String path, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void convertImageAtPathAsBase64(String path, Promise promise);
 }

--- a/android/generated/jni/RNSimpleHeic2jpgSpec-generated.cpp
+++ b/android/generated/jni/RNSimpleHeic2jpgSpec-generated.cpp
@@ -17,9 +17,15 @@ static facebook::jsi::Value __hostFunction_NativeSimpleHeic2jpgSpecJSI_convertIm
   return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, PromiseKind, "convertImageAtPath", "(Ljava/lang/String;Lcom/facebook/react/bridge/Promise;)V", args, count, cachedMethodId);
 }
 
+static facebook::jsi::Value __hostFunction_NativeSimpleHeic2jpgSpecJSI_convertImageAtPathAsBase64(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
+  static jmethodID cachedMethodId = nullptr;
+  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, PromiseKind, "convertImageAtPathAsBase64", "(Ljava/lang/String;Lcom/facebook/react/bridge/Promise;)V", args, count, cachedMethodId);
+}
+
 NativeSimpleHeic2jpgSpecJSI::NativeSimpleHeic2jpgSpecJSI(const JavaTurboModule::InitParams &params)
   : JavaTurboModule(params) {
   methodMap_["convertImageAtPath"] = MethodMetadata {1, __hostFunction_NativeSimpleHeic2jpgSpecJSI_convertImageAtPath};
+  methodMap_["convertImageAtPathAsBase64"] = MethodMetadata {1, __hostFunction_NativeSimpleHeic2jpgSpecJSI_convertImageAtPathAsBase64};
 }
 
 std::shared_ptr<TurboModule> RNSimpleHeic2jpgSpec_ModuleProvider(const std::string &moduleName, const JavaTurboModule::InitParams &params) {

--- a/android/generated/jni/react/renderer/components/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpecJSI-generated.cpp
+++ b/android/generated/jni/react/renderer/components/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpecJSI-generated.cpp
@@ -17,10 +17,17 @@ static jsi::Value __hostFunction_NativeSimpleHeic2jpgCxxSpecJSI_convertImageAtPa
     count <= 0 ? throw jsi::JSError(rt, "Expected argument in position 0 to be passed") : args[0].asString(rt)
   );
 }
+static jsi::Value __hostFunction_NativeSimpleHeic2jpgCxxSpecJSI_convertImageAtPathAsBase64(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSimpleHeic2jpgCxxSpecJSI *>(&turboModule)->convertImageAtPathAsBase64(
+    rt,
+    count <= 0 ? throw jsi::JSError(rt, "Expected argument in position 0 to be passed") : args[0].asString(rt)
+  );
+}
 
 NativeSimpleHeic2jpgCxxSpecJSI::NativeSimpleHeic2jpgCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
   : TurboModule("SimpleHeic2jpg", jsInvoker) {
   methodMap_["convertImageAtPath"] = MethodMetadata {1, __hostFunction_NativeSimpleHeic2jpgCxxSpecJSI_convertImageAtPath};
+  methodMap_["convertImageAtPathAsBase64"] = MethodMetadata {1, __hostFunction_NativeSimpleHeic2jpgCxxSpecJSI_convertImageAtPathAsBase64};
 }
 
 

--- a/android/generated/jni/react/renderer/components/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpecJSI.h
+++ b/android/generated/jni/react/renderer/components/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpecJSI.h
@@ -21,6 +21,7 @@ protected:
 
 public:
   virtual jsi::Value convertImageAtPath(jsi::Runtime &rt, jsi::String path) = 0;
+  virtual jsi::Value convertImageAtPathAsBase64(jsi::Runtime &rt, jsi::String path) = 0;
 
 };
 
@@ -54,6 +55,14 @@ private:
 
       return bridging::callFromJs<jsi::Value>(
           rt, &T::convertImageAtPath, jsInvoker_, instance_, std::move(path));
+    }
+    jsi::Value convertImageAtPathAsBase64(jsi::Runtime &rt, jsi::String path) override {
+      static_assert(
+          bridging::getParameterCount(&T::convertImageAtPathAsBase64) == 2,
+          "Expected convertImageAtPathAsBase64(...) to have 2 parameters");
+
+      return bridging::callFromJs<jsi::Value>(
+          rt, &T::convertImageAtPathAsBase64, jsInvoker_, instance_, std::move(path));
     }
 
   private:

--- a/android/src/main/java/com/simpleheic2jpg/SimpleHeic2jpgModuleImpl.kt
+++ b/android/src/main/java/com/simpleheic2jpg/SimpleHeic2jpgModuleImpl.kt
@@ -2,6 +2,7 @@ package com.simpleheic2jpg
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.util.Base64
 import androidx.exifinterface.media.ExifInterface
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -94,39 +95,88 @@ object SimpleHeic2jpgModuleImpl {
     return cacheFile.absolutePath
   }
 
+  private fun isHeicOrHeif(fileExtension: String): Boolean {
+    return fileExtension == "heic" || fileExtension == "heif"
+  }
+
+  private fun isSupportedBase64Passthrough(fileExtension: String): Boolean {
+    return fileExtension == "jpg" || fileExtension == "jpeg" || fileExtension == "png"
+  }
+
+  private fun normalizeLocalFilePath(filePath: String): String {
+    return filePath.removePrefix("file://")
+  }
+
+  private fun convertHeicToCache(context: ReactApplicationContext, correctedFilePath: String): String {
+    val options = BitmapFactory.Options()
+    options.inPreferredConfig = Bitmap.Config.ARGB_8888
+    val bitmap = BitmapFactory.decodeFile(correctedFilePath, options)
+    if (bitmap != null) {
+      var cachePath: String? = null
+      try {
+        cachePath = saveBitmapToCache(context, bitmap)
+        val exif = ExifInterface(correctedFilePath)
+        val newExif = ExifInterface(cachePath)
+        for (tagName in EXIF_TAG_LIST) {
+          val attribute = exif.getAttribute(tagName)
+          if (attribute != null) {
+            newExif.setAttribute(tagName, attribute)
+          }
+        }
+        newExif.saveAttributes()
+        return cachePath
+      } catch (ex: Exception) {
+        if (cachePath != null) {
+          File(cachePath).delete()
+        }
+        throw ex
+      } finally {
+        bitmap.recycle()
+      }
+    } else {
+      throw Exception("Failed to convert image. Bitmap is null.")
+    }
+  }
+
+  private fun encodeFileAsBase64(file: File): String {
+    return Base64.encodeToString(file.readBytes(), Base64.NO_WRAP)
+  }
+
   fun convertImageAtPath(context: ReactApplicationContext, filePath: String, promise: Promise) {
     try {
       val fileExtension = getFileExtension(filePath)
 
-      if (fileExtension == "heic" || fileExtension == "heif") {
-        val correctedFilePath = filePath.removePrefix("file://")
-        val options = BitmapFactory.Options()
-        options.inPreferredConfig = Bitmap.Config.ARGB_8888
-        val bitmap = BitmapFactory.decodeFile(correctedFilePath, options)
-        if (bitmap != null) {
-          try {
-            val cachePath = saveBitmapToCache(context, bitmap)
-            val exif = ExifInterface(correctedFilePath)
-            val newExif = ExifInterface(cachePath)
-            for (tagName in EXIF_TAG_LIST) {
-              val attribute = exif.getAttribute(tagName)
-              if (attribute != null) {
-                newExif.setAttribute(tagName, attribute)
-              }
-            }
-            newExif.saveAttributes()
-            promise.resolve(cachePath)
-          } finally {
-            bitmap.recycle()
-          }
-        } else {
-          promise.reject(Exception("Failed to convert image. Bitmap is null."))
-        }
+      if (isHeicOrHeif(fileExtension)) {
+        val correctedFilePath = normalizeLocalFilePath(filePath)
+        promise.resolve(convertHeicToCache(context, correctedFilePath))
       } else {
         promise.resolve(filePath)
       }
     } catch (ex: Exception) {
       promise.reject(ex)
+    }
+  }
+
+  fun convertImageAtPathAsBase64(context: ReactApplicationContext, filePath: String, promise: Promise) {
+    var generatedCachePath: String? = null
+    try {
+      val fileExtension = getFileExtension(filePath)
+      val correctedFilePath = normalizeLocalFilePath(filePath)
+
+      if (isHeicOrHeif(fileExtension)) {
+        generatedCachePath = convertHeicToCache(context, correctedFilePath)
+        promise.resolve(encodeFileAsBase64(File(generatedCachePath)))
+      } else if (isSupportedBase64Passthrough(fileExtension)) {
+        promise.resolve(encodeFileAsBase64(File(correctedFilePath)))
+      } else {
+        promise.reject(Exception("Unsupported image format for base64 conversion."))
+      }
+    } catch (ex: Exception) {
+      promise.reject(ex)
+    } finally {
+      if (generatedCachePath != null) {
+        File(generatedCachePath).delete()
+      }
     }
   }
 

--- a/android/src/newarch/com/simpleheic2jpg/SimpleHeic2jpgModule.kt
+++ b/android/src/newarch/com/simpleheic2jpg/SimpleHeic2jpgModule.kt
@@ -14,5 +14,9 @@ class SimpleHeic2jpgModule(reactContext: ReactApplicationContext?) :
   override fun convertImageAtPath(path: String, promise: Promise) {
     SimpleHeic2jpgModuleImpl.convertImageAtPath(reactApplicationContext, path, promise)
   }
+
+  override fun convertImageAtPathAsBase64(path: String, promise: Promise) {
+    SimpleHeic2jpgModuleImpl.convertImageAtPathAsBase64(reactApplicationContext, path, promise)
+  }
 }
 

--- a/android/src/oldarch/com/simpleheic2jpg/SimpleHeic2jpgModule.kt
+++ b/android/src/oldarch/com/simpleheic2jpg/SimpleHeic2jpgModule.kt
@@ -17,5 +17,10 @@ class SimpleHeic2jpgModule(reactContext: ReactApplicationContext?) :
   fun convertImageAtPath(path: String, promise: Promise) {
     SimpleHeic2jpgModuleImpl.convertImageAtPath(reactApplicationContext, path, promise)
   }
+
+  @ReactMethod
+  fun convertImageAtPathAsBase64(path: String, promise: Promise) {
+    SimpleHeic2jpgModuleImpl.convertImageAtPathAsBase64(reactApplicationContext, path, promise)
+  }
 }
 

--- a/ios/SimpleHeic2jpg.mm
+++ b/ios/SimpleHeic2jpg.mm
@@ -16,6 +16,12 @@ reject:(RCTPromiseRejectBlock)reject {
   [self convertImageAtPathImplementation:path resolve:resolve reject:reject];
 }
 
+- (void)convertImageAtPathAsBase64:(NSString *)path
+resolve:(RCTPromiseResolveBlock)resolve
+reject:(RCTPromiseRejectBlock)reject {
+  [self convertImageAtPathAsBase64Implementation:path resolve:resolve reject:reject];
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
 (const facebook::react::ObjCTurboModule::InitParams &)params {
   return std::make_shared<facebook::react::NativeSimpleHeic2jpgSpecJSI>(params);
@@ -26,6 +32,12 @@ RCT_EXPORT_METHOD(convertImageAtPath:(NSString *)path
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
   [self convertImageAtPathImplementation:path resolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(convertImageAtPathAsBase64:(NSString *)path
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  [self convertImageAtPathAsBase64Implementation:path resolve:resolve reject:reject];
 }
 #endif
 
@@ -109,6 +121,102 @@ RCT_EXPORT_METHOD(convertImageAtPath:(NSString *)path
   }
 }
 
+- (void)convertImageAtPathAsBase64Implementation:(NSString *)path
+                                        resolve:(RCTPromiseResolveBlock)resolve
+                                         reject:(RCTPromiseRejectBlock)reject {
+  CGImageSourceRef imageSource = NULL;
+  NSString *generatedJPEGPath = nil;
+
+  @try {
+    if (!path || [path isEqualToString:@""]) {
+      reject(@"Invalid Path", @"The path is invalid or empty", nil);
+      return;
+    }
+
+    NSURL *url = [self normalizedLocalFileURLForPath:path reject:reject];
+    if (!url) {
+      return;
+    }
+
+    imageSource = CGImageSourceCreateWithURL((__bridge CFURLRef)url, NULL);
+    if (!imageSource) {
+      reject(@"Error Creating Image Source", @"Cannot create image source", nil);
+      return;
+    }
+
+    CFStringRef imageType = CGImageSourceGetType(imageSource);
+    if (!imageType) {
+      reject(@"Error Getting Image Type", @"Cannot get image type", nil);
+      return;
+    }
+
+    NSData *base64SourceData = nil;
+
+    if (CFStringCompare(imageType, CFSTR("public.heic"), 0) == kCFCompareEqualTo ||
+        CFStringCompare(imageType, CFSTR("public.heif"), 0) == kCFCompareEqualTo) {
+      generatedJPEGPath = [self uniqueTemporaryJPEGOutputPathForFilePath:url.path];
+      NSURL *destinationURL = [NSURL fileURLWithPath:generatedJPEGPath];
+
+      NSData *tempImageData = [NSData dataWithContentsOfURL:url];
+      UIImage *image = [UIImage imageWithData:tempImageData];
+      if (!image) {
+        reject(@"Error Loading Image", @"Failed to load image from path", nil);
+        return;
+      }
+
+      CGImageRef cgImage = image.CGImage;
+      CGColorSpaceRef colorSpace = cgImage ? CGImageGetColorSpace(cgImage) : NULL;
+      if (!cgImage || !colorSpace) {
+        reject(@"Error Processing Image", @"Failed to process image data", nil);
+        return;
+      }
+
+      CIImage *ciImage = [CIImage imageWithCGImage:cgImage];
+      CIContext *context = [CIContext context];
+      NSData *jpegData = [context JPEGRepresentationOfImage:ciImage
+                                                 colorSpace:colorSpace
+                                                    options:@{}];
+      if (!jpegData) {
+        reject(@"Image Conversion Failed", @"Image conversion to JPEG representation failed", nil);
+        return;
+      }
+
+      if (![self writeFinalizedJPEGData:jpegData
+                            imageSource:imageSource
+                         destinationURL:destinationURL
+                                  reject:reject]) {
+        return;
+      }
+
+      // Read finalized destination bytes so metadata/finalization are included.
+      base64SourceData = [NSData dataWithContentsOfURL:destinationURL];
+    } else if (CFStringCompare(imageType, CFSTR("public.jpeg"), 0) == kCFCompareEqualTo ||
+               CFStringCompare(imageType, CFSTR("public.png"), 0) == kCFCompareEqualTo) {
+      // JPEG/JPG/PNG inputs are caller-owned; read original bytes and never delete them.
+      base64SourceData = [NSData dataWithContentsOfURL:url];
+    } else {
+      reject(@"Unsupported Image Format", @"Unsupported image format", nil);
+      return;
+    }
+
+    if (!base64SourceData) {
+      reject(@"Error Reading Image Data", @"Failed to read image data for base64 encoding", nil);
+      return;
+    }
+
+    resolve([base64SourceData base64EncodedStringWithOptions:0]);
+  } @catch (NSException *exception) {
+    reject(@"Error", exception.reason, nil);
+  } @finally {
+    if (imageSource) {
+      CFRelease(imageSource);
+    }
+    if (generatedJPEGPath) {
+      [[NSFileManager defaultManager] removeItemAtPath:generatedJPEGPath error:nil];
+    }
+  }
+}
+
 - (NSURL *)normalizedLocalFileURLForPath:(NSString *)path
                                   reject:(RCTPromiseRejectBlock)reject {
   NSRange colonRange = [path rangeOfString:@":"];
@@ -158,10 +266,15 @@ RCT_EXPORT_METHOD(convertImageAtPath:(NSString *)path
   return [directory stringByAppendingPathComponent:fallbackFileName];
 }
 
-- (void)createImageDestination:(NSData *)imageData
+- (NSString *)uniqueTemporaryJPEGOutputPathForFilePath:(NSString *)filePath {
+  NSString *baseName = [[filePath lastPathComponent] stringByDeletingPathExtension];
+  NSString *fileName = [NSString stringWithFormat:@"%@-%@.jpeg", baseName, [NSUUID UUID].UUIDString];
+  return [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
+}
+
+- (BOOL)writeFinalizedJPEGData:(NSData *)imageData
                    imageSource:(CGImageSourceRef)imageSource
                 destinationURL:(NSURL *)destinationURL
-                       resolve:(RCTPromiseResolveBlock)resolve
                         reject:(RCTPromiseRejectBlock)reject {
   CGImageSourceRef source = NULL;
   CGImageDestinationRef destination = NULL;
@@ -172,13 +285,13 @@ RCT_EXPORT_METHOD(convertImageAtPath:(NSString *)path
     source = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, options);
     if (!source) {
       reject(@"Error Creating Image Source", @"Failed to create image source with JPEG data", nil);
-      return;
+      return NO;
     }
 
     destination = CGImageDestinationCreateWithURL((__bridge CFURLRef)destinationURL, CFSTR("public.jpeg"), 1, NULL);
     if (!destination) {
       reject(@"Error Creating Image Destination", [NSString stringWithFormat:@"Failed to create image destination at URL: %@", destinationURL], nil);
-      return;
+      return NO;
     }
 
     imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
@@ -186,12 +299,13 @@ RCT_EXPORT_METHOD(convertImageAtPath:(NSString *)path
 
     if (!CGImageDestinationFinalize(destination)) {
       reject(@"Error Writing Image", @"Failed to finalize image destination", nil);
-      return;
+      return NO;
     }
 
-    resolve(destinationURL.path);
+    return YES;
   } @catch (NSException *exception) {
     reject(@"Error Writing Image", exception.reason, nil);
+    return NO;
   } @finally {
     if (imageProperties) {
       CFRelease(imageProperties);
@@ -202,6 +316,19 @@ RCT_EXPORT_METHOD(convertImageAtPath:(NSString *)path
     if (source) {
       CFRelease(source);
     }
+  }
+}
+
+- (void)createImageDestination:(NSData *)imageData
+                   imageSource:(CGImageSourceRef)imageSource
+                destinationURL:(NSURL *)destinationURL
+                       resolve:(RCTPromiseResolveBlock)resolve
+                        reject:(RCTPromiseRejectBlock)reject {
+  if ([self writeFinalizedJPEGData:imageData
+                       imageSource:imageSource
+                    destinationURL:destinationURL
+                             reject:reject]) {
+    resolve(destinationURL.path);
   }
 }
 

--- a/ios/generated/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpec-generated.mm
+++ b/ios/generated/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpec-generated.mm
@@ -25,15 +25,22 @@
 
 
 namespace facebook::react {
-  
+
     static facebook::jsi::Value __hostFunction_NativeSimpleHeic2jpgSpecJSI_convertImageAtPath(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
       return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, PromiseKind, "convertImageAtPath", @selector(convertImageAtPath:resolve:reject:), args, count);
     }
 
+    static facebook::jsi::Value __hostFunction_NativeSimpleHeic2jpgSpecJSI_convertImageAtPathAsBase64(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
+      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, PromiseKind, "convertImageAtPathAsBase64", @selector(convertImageAtPathAsBase64:resolve:reject:), args, count);
+    }
+
   NativeSimpleHeic2jpgSpecJSI::NativeSimpleHeic2jpgSpecJSI(const ObjCTurboModule::InitParams &params)
     : ObjCTurboModule(params) {
-      
+
         methodMap_["convertImageAtPath"] = MethodMetadata {1, __hostFunction_NativeSimpleHeic2jpgSpecJSI_convertImageAtPath};
-        
+
+
+        methodMap_["convertImageAtPathAsBase64"] = MethodMetadata {1, __hostFunction_NativeSimpleHeic2jpgSpecJSI_convertImageAtPathAsBase64};
+
   }
 } // namespace facebook::react

--- a/ios/generated/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpec.h
+++ b/ios/generated/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpec.h
@@ -36,6 +36,9 @@
 - (void)convertImageAtPath:(NSString *)path
                    resolve:(RCTPromiseResolveBlock)resolve
                     reject:(RCTPromiseRejectBlock)reject;
+- (void)convertImageAtPathAsBase64:(NSString *)path
+                           resolve:(RCTPromiseResolveBlock)resolve
+                            reject:(RCTPromiseRejectBlock)reject;
 
 @end
 

--- a/ios/generated/RNSimpleHeic2jpgSpecJSI-generated.cpp
+++ b/ios/generated/RNSimpleHeic2jpgSpecJSI-generated.cpp
@@ -17,10 +17,17 @@ static jsi::Value __hostFunction_NativeSimpleHeic2jpgCxxSpecJSI_convertImageAtPa
     count <= 0 ? throw jsi::JSError(rt, "Expected argument in position 0 to be passed") : args[0].asString(rt)
   );
 }
+static jsi::Value __hostFunction_NativeSimpleHeic2jpgCxxSpecJSI_convertImageAtPathAsBase64(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSimpleHeic2jpgCxxSpecJSI *>(&turboModule)->convertImageAtPathAsBase64(
+    rt,
+    count <= 0 ? throw jsi::JSError(rt, "Expected argument in position 0 to be passed") : args[0].asString(rt)
+  );
+}
 
 NativeSimpleHeic2jpgCxxSpecJSI::NativeSimpleHeic2jpgCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
   : TurboModule("SimpleHeic2jpg", jsInvoker) {
   methodMap_["convertImageAtPath"] = MethodMetadata {1, __hostFunction_NativeSimpleHeic2jpgCxxSpecJSI_convertImageAtPath};
+  methodMap_["convertImageAtPathAsBase64"] = MethodMetadata {1, __hostFunction_NativeSimpleHeic2jpgCxxSpecJSI_convertImageAtPathAsBase64};
 }
 
 

--- a/ios/generated/RNSimpleHeic2jpgSpecJSI.h
+++ b/ios/generated/RNSimpleHeic2jpgSpecJSI.h
@@ -21,6 +21,7 @@ protected:
 
 public:
   virtual jsi::Value convertImageAtPath(jsi::Runtime &rt, jsi::String path) = 0;
+  virtual jsi::Value convertImageAtPathAsBase64(jsi::Runtime &rt, jsi::String path) = 0;
 
 };
 
@@ -54,6 +55,14 @@ private:
 
       return bridging::callFromJs<jsi::Value>(
           rt, &T::convertImageAtPath, jsInvoker_, instance_, std::move(path));
+    }
+    jsi::Value convertImageAtPathAsBase64(jsi::Runtime &rt, jsi::String path) override {
+      static_assert(
+          bridging::getParameterCount(&T::convertImageAtPathAsBase64) == 2,
+          "Expected convertImageAtPathAsBase64(...) to have 2 parameters");
+
+      return bridging::callFromJs<jsi::Value>(
+          rt, &T::convertImageAtPathAsBase64, jsInvoker_, instance_, std::move(path));
     }
 
   private:

--- a/src/NativeSimpleHeic2jpg.ts
+++ b/src/NativeSimpleHeic2jpg.ts
@@ -3,10 +3,12 @@ import { TurboModuleRegistry, NativeModules } from 'react-native';
 
 export interface Spec extends TurboModule {
   convertImageAtPath(path: string): Promise<string>;
+  convertImageAtPathAsBase64(path: string): Promise<string>;
 }
 
 export interface ImageConverterInterface {
   convertImageAtPath(path: string): Promise<string>;
+  convertImageAtPathAsBase64(path: string): Promise<string>;
 }
 
 // TurboModuleRegistry로 TurboModule 가져오기 (New Architecture)

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,10 +1,14 @@
 let mockConvertImageAtPath: jest.Mock | undefined;
+let mockConvertImageAtPathAsBase64: jest.Mock | undefined;
 
 jest.mock('../NativeSimpleHeic2jpg', () => ({
   __esModule: true,
   default: {
     get convertImageAtPath() {
       return mockConvertImageAtPath;
+    },
+    get convertImageAtPathAsBase64() {
+      return mockConvertImageAtPathAsBase64;
     },
   },
 }));
@@ -13,6 +17,7 @@ import { convertImage } from '../index';
 
 beforeEach(() => {
   mockConvertImageAtPath = jest.fn();
+  mockConvertImageAtPathAsBase64 = jest.fn();
 });
 
 afterEach(() => {
@@ -27,6 +32,7 @@ describe('convertImage', () => {
       'file:///tmp/output.jpeg'
     );
     expect(mockConvertImageAtPath).toHaveBeenCalledWith('/tmp/input.heic');
+    expect(mockConvertImageAtPathAsBase64).not.toHaveBeenCalled();
   });
 
   it('prefixes raw native paths with file URI scheme', async () => {
@@ -37,11 +43,41 @@ describe('convertImage', () => {
     );
   });
 
+  it('returns raw base64 strings without URI prefixing', async () => {
+    mockConvertImageAtPathAsBase64?.mockResolvedValue('abc123+/=');
+
+    await expect(
+      convertImage('/tmp/input.heic', { returnBase64: true })
+    ).resolves.toBe('abc123+/=');
+    expect(mockConvertImageAtPathAsBase64).toHaveBeenCalledWith(
+      '/tmp/input.heic'
+    );
+    expect(mockConvertImageAtPath).not.toHaveBeenCalled();
+  });
+
+  it('does not add a data URI prefix to base64 results', async () => {
+    mockConvertImageAtPathAsBase64?.mockResolvedValue('/9j/4AAQSkZJRgABAQ==');
+
+    await expect(
+      convertImage('/tmp/input.heic', { returnBase64: true })
+    ).resolves.toBe('/9j/4AAQSkZJRgABAQ==');
+  });
+
   it('throws when native conversion method is unavailable', async () => {
     mockConvertImageAtPath = undefined;
 
     await expect(convertImage('/tmp/input.heic')).rejects.toThrow(
       'SimpleHeic2jpg module is not available'
+    );
+  });
+
+  it('throws when native base64 conversion method is unavailable', async () => {
+    mockConvertImageAtPathAsBase64 = undefined;
+
+    await expect(
+      convertImage('/tmp/input.heic', { returnBase64: true })
+    ).rejects.toThrow(
+      'SimpleHeic2jpg base64 conversion method is not available'
     );
   });
 
@@ -53,10 +89,27 @@ describe('convertImage', () => {
     );
   });
 
+  it('throws when native base64 conversion returns an invalid result', async () => {
+    mockConvertImageAtPathAsBase64?.mockResolvedValue('');
+
+    await expect(
+      convertImage('/tmp/input.heic', { returnBase64: true })
+    ).rejects.toThrow('convertImageAtPathAsBase64 returned an invalid result');
+  });
+
   it('propagates native conversion failures', async () => {
     const nativeError = new Error('native conversion failed');
     mockConvertImageAtPath?.mockRejectedValue(nativeError);
 
     await expect(convertImage('/tmp/input.heic')).rejects.toBe(nativeError);
+  });
+
+  it('propagates native base64 conversion failures', async () => {
+    const nativeError = new Error('native base64 conversion failed');
+    mockConvertImageAtPathAsBase64?.mockRejectedValue(nativeError);
+
+    await expect(
+      convertImage('/tmp/input.heic', { returnBase64: true })
+    ).rejects.toBe(nativeError);
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,23 +1,41 @@
 import SimpleHeic2jpg from './NativeSimpleHeic2jpg';
 
-async function convertImage(imagePath: string): Promise<string> {
+export type ConvertImageOptions = {
+  returnBase64?: boolean;
+};
+
+async function convertImage(
+  imagePath: string,
+  options?: ConvertImageOptions
+): Promise<string> {
   if (!SimpleHeic2jpg || !SimpleHeic2jpg.convertImageAtPath) {
     throw new Error('SimpleHeic2jpg module is not available');
   }
 
-  try {
-    const newPath = await SimpleHeic2jpg.convertImageAtPath(imagePath);
-    if (!newPath) {
-      throw new Error('convertImageAtPath returned an invalid result');
+  if (options?.returnBase64) {
+    if (!SimpleHeic2jpg.convertImageAtPathAsBase64) {
+      throw new Error(
+        'SimpleHeic2jpg base64 conversion method is not available'
+      );
     }
 
-    if (newPath.startsWith('file://')) {
-      return newPath;
+    const base64 = await SimpleHeic2jpg.convertImageAtPathAsBase64(imagePath);
+    if (!base64) {
+      throw new Error('convertImageAtPathAsBase64 returned an invalid result');
     }
-    return `file://${newPath}`;
-  } catch (error) {
-    throw error;
+
+    return base64;
   }
+
+  const newPath = await SimpleHeic2jpg.convertImageAtPath(imagePath);
+  if (!newPath) {
+    throw new Error('convertImageAtPath returned an invalid result');
+  }
+
+  if (newPath.startsWith('file://')) {
+    return newPath;
+  }
+  return `file://${newPath}`;
 }
 
 export { convertImage };


### PR DESCRIPTION
## Summary
Issue #5의 요구사항인 “변환 결과를 파일 URI가 아닌 raw base64 문자열로 직접 받는 모드”를 opt-in API로 추가했습니다. 기본 `convertImage(path)` 동작은 기존처럼 `file://` JPEG URI를 반환하도록 유지해 하위 호환성을 보존했습니다.

## Changes

### 기능 추가/수정
- **convertImage**: `convertImage(path, { returnBase64: true })` 옵션을 추가해 raw base64 문자열을 반환하도록 분기했습니다.
- **NativeSimpleHeic2jpg**: 기존 `convertImageAtPath(path)`는 유지하고, base64 전용 `convertImageAtPathAsBase64(path)`를 별도 native method로 추가했습니다.
- **iOS SimpleHeic2jpg**: HEIC/HEIF는 임시 JPEG로 변환 후 bytes를 base64로 읽고, 내부 생성 임시 파일만 정리하도록 구현했습니다.
- **Android SimpleHeic2jpg**: HEIC/HEIF는 cache JPEG 변환 후 `Base64.NO_WRAP`으로 반환하고, 내부 생성 cache 파일을 `finally`에서 정리하도록 구현했습니다.

### Codegen / 아키텍처 호환성
- **iOS generated specs**: new architecture JSI/spec 산출물에 `convertImageAtPathAsBase64`를 반영했습니다.
- **Android generated specs**: Java/JNI/new architecture 산출물에 `convertImageAtPathAsBase64`를 반영했습니다.
- **Old/New Architecture wrappers**: Android old/new arch module wrapper 모두 새 native method를 export하도록 맞췄습니다.

### 문서 및 테스트
- **README.md**: `returnBase64` 사용 예시와 raw base64 반환 규칙을 문서화했습니다.
- **src/__tests__/index.test.tsx**: 기본 URI 반환, base64 옵션 분기, invalid option fallback, native rejection 전파를 검증했습니다.

### API/Export 변경
```diff
- convertImage(path: string): Promise<string>
+ convertImage(path: string, options?: { returnBase64?: boolean }): Promise<string>
```

```diff
 export interface Spec extends TurboModule {
   convertImageAtPath(path: string): Promise<string>;
+  convertImageAtPathAsBase64(path: string): Promise<string>;
 }
```

> **Note**: Breaking change는 없습니다. 기본 호출은 계속 `file://` URI를 반환하며, base64 반환은 `{ returnBase64: true }`를 명시한 경우에만 활성화됩니다.

## Test
- [x] `yarn test src/__tests__/index.test.tsx --runInBand`로 JS API 분기와 rejection 전파 검증
- [x] `yarn typecheck`로 TypeScript API 타입 검증
- [x] `yarn lint`로 JS/TS lint 검증
- [x] `yarn prepare`로 codegen 및 빌드 산출물 재생성 검증
- [x] `./example/android/gradlew -p example/android :react-native-simple-heic2jpg:compileDebugKotlin -PnewArchEnabled=false`로 Android old arch 컴파일 검증
- [x] `./example/android/gradlew -p example/android :react-native-simple-heic2jpg:compileDebugKotlin`로 Android new arch 컴파일 검증
- [x] `xcodebuild -workspace example/ios/SimpleHeic2jpgExample.xcworkspace -scheme SimpleHeic2jpgExample -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`로 iOS simulator build 검증
- [x] `git diff --check`로 whitespace/error marker 검증
- [ ] 실제 디바이스에서 HEIC/HEIF/JPEG/PNG fixture matrix로 runtime 반환값 검증

Closes #5
