### PR TITLE
feat(api): add quality option for HEIC/HEIF to JPEG conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ To receive raw base64 instead of a file URI:
 const base64 = await convertImage(path, { returnBase64: true });
 ```
 
+### JPEG quality
+
+Pass `quality` to control the JPEG encode quality of converted HEIC/HEIF images:
+
+```js
+// Smaller file, default quality
+await convertImage(path);
+
+// Higher quality, larger file
+await convertImage(path, { quality: 95 });
+```
+
+- `quality` is an integer from `0` (smallest) to `100` (best). It defaults to `80`.
+- Out-of-range values are clamped to `0`–`100`; fractional values are rounded.
+- Quality only applies to **HEIC/HEIF inputs that are converted**. JPEG and PNG inputs pass through without re-encoding, so `quality` has no effect on them.
+
+> Note: this release standardizes the JPEG quality across platforms. Previously Android encoded at `100` and iOS used the system default; both now default to `80`, so converted JPEGs are noticeably smaller. Pass `quality: 100` for the maximum-quality (largest) output.
+
 ### Input path contract
 
 `convertImage` accepts local image files as either:

--- a/android/generated/jni/react/renderer/components/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpecJSI.h
+++ b/android/generated/jni/react/renderer/components/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpecJSI.h
@@ -17,14 +17,15 @@ namespace facebook::react {
 
 #pragma mark - NativeSimpleHeic2jpgConvertNativeOptions
 
-template <typename P0, typename P1, typename P2, typename P3>
+template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct NativeSimpleHeic2jpgConvertNativeOptions {
   P0 stripExif{};
   P1 stripGps{};
-  P2 gpsLatitude{};
-  P3 gpsLongitude;
+  P2 quality{};
+  P3 gpsLatitude{};
+  P4 gpsLongitude;
   bool operator==(const NativeSimpleHeic2jpgConvertNativeOptions &other) const {
-    return stripExif == other.stripExif && stripGps == other.stripGps && gpsLatitude == other.gpsLatitude && gpsLongitude == other.gpsLongitude;
+    return stripExif == other.stripExif && stripGps == other.stripGps && quality == other.quality && gpsLatitude == other.gpsLatitude && gpsLongitude == other.gpsLongitude;
   }
 };
 
@@ -39,6 +40,7 @@ struct NativeSimpleHeic2jpgConvertNativeOptionsBridging {
     T result{
       bridging::fromJs<decltype(types.stripExif)>(rt, value.getProperty(rt, "stripExif"), jsInvoker),
       bridging::fromJs<decltype(types.stripGps)>(rt, value.getProperty(rt, "stripGps"), jsInvoker),
+      bridging::fromJs<decltype(types.quality)>(rt, value.getProperty(rt, "quality"), jsInvoker),
       bridging::fromJs<decltype(types.gpsLatitude)>(rt, value.getProperty(rt, "gpsLatitude"), jsInvoker),
       bridging::fromJs<decltype(types.gpsLongitude)>(rt, value.getProperty(rt, "gpsLongitude"), jsInvoker)};
     return result;
@@ -49,6 +51,9 @@ struct NativeSimpleHeic2jpgConvertNativeOptionsBridging {
     return bridging::toJs(rt, value);
   }
   static bool stripGpsToJs(jsi::Runtime &rt, decltype(types.stripGps) value) {
+    return bridging::toJs(rt, value);
+  }
+  static double qualityToJs(jsi::Runtime &rt, decltype(types.quality) value) {
     return bridging::toJs(rt, value);
   }
   static double gpsLatitudeToJs(jsi::Runtime &rt, decltype(types.gpsLatitude) value) {
@@ -66,6 +71,7 @@ struct NativeSimpleHeic2jpgConvertNativeOptionsBridging {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, "stripExif", bridging::toJs(rt, value.stripExif, jsInvoker));
     result.setProperty(rt, "stripGps", bridging::toJs(rt, value.stripGps, jsInvoker));
+    result.setProperty(rt, "quality", bridging::toJs(rt, value.quality, jsInvoker));
     if (value.gpsLatitude) {
       result.setProperty(rt, "gpsLatitude", bridging::toJs(rt, value.gpsLatitude.value(), jsInvoker));
     }

--- a/android/src/main/java/com/simpleheic2jpg/SimpleHeic2jpgModuleImpl.kt
+++ b/android/src/main/java/com/simpleheic2jpg/SimpleHeic2jpgModuleImpl.kt
@@ -195,8 +195,7 @@ object SimpleHeic2jpgModuleImpl {
   // Copies whitelisted EXIF tags from srcPath onto dstPath.
   // stripGps: drop GPS tags only. stripExif: drop everything except orientation
   // (orientation must survive because BitmapFactory does not rotate pixels — the tag
-  // is the only thing keeping the image upright). P0 callers pass false/false; the
-  // strip branches are wired up here so P1 only has to thread the options through.
+  // is the only thing keeping the image upright).
   //
   // Orientation policy: tag preserved, pixels NOT rotated. BitmapFactory.decodeFile
   // returns raw, unrotated pixels, so copying TAG_ORIENTATION leaves the consumer to

--- a/android/src/main/java/com/simpleheic2jpg/SimpleHeic2jpgModuleImpl.kt
+++ b/android/src/main/java/com/simpleheic2jpg/SimpleHeic2jpgModuleImpl.kt
@@ -123,11 +123,11 @@ object SimpleHeic2jpgModuleImpl {
     throw IOException("Failed to create image conversion cache file.")
   }
 
-  private fun saveBitmapToCache(context: ReactApplicationContext, bitmap: Bitmap): String {
+  private fun saveBitmapToCache(context: ReactApplicationContext, bitmap: Bitmap, quality: Int): String {
     val cacheFile = createCacheFile(ensureCacheDir(context))
     try {
       FileOutputStream(cacheFile).use { outputStream ->
-        if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)) {
+        if (!bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream)) {
           throw IOException("Failed to encode image as JPEG.")
         }
       }
@@ -246,11 +246,22 @@ object SimpleHeic2jpgModuleImpl {
   private fun ReadableMap?.optionDouble(key: String): Double? =
     if (this != null && this.hasKey(key) && !this.isNull(key)) this.getDouble(key) else null
 
+  // Reads the JPEG quality option, clamped to 0–100. The JS wrapper always sends a
+  // normalized default (80), so absence only happens for a direct native caller — default
+  // to 80 to match. Read as a Double (a JS number can marshal as a double even when
+  // integral) and round rather than truncate, matching the wrapper.
+  internal fun ReadableMap?.optionQuality(): Int {
+    val value =
+      if (this != null && this.hasKey("quality") && !this.isNull("quality")) this.getDouble("quality") else 80.0
+    return Math.round(value).toInt().coerceIn(0, 100)
+  }
+
   private fun convertHeicToCache(
     context: ReactApplicationContext,
     correctedFilePath: String,
     stripExif: Boolean,
     stripGps: Boolean,
+    quality: Int,
     gpsLatitude: Double?,
     gpsLongitude: Double?
   ): String {
@@ -275,7 +286,7 @@ object SimpleHeic2jpgModuleImpl {
 
     var cachePath: String? = null
     try {
-      cachePath = saveBitmapToCache(context, bitmap)
+      cachePath = saveBitmapToCache(context, bitmap, quality)
       copyExif(correctedFilePath, cachePath, stripExif, stripGps, gpsLatitude, gpsLongitude)
       return cachePath
     } catch (ex: Exception) {
@@ -319,6 +330,7 @@ object SimpleHeic2jpgModuleImpl {
             correctedFilePath,
             options.optionFlag("stripExif"),
             options.optionFlag("stripGps"),
+            options.optionQuality(),
             options.optionDouble("gpsLatitude"),
             options.optionDouble("gpsLongitude")
           )
@@ -360,6 +372,7 @@ object SimpleHeic2jpgModuleImpl {
           correctedFilePath,
           options.optionFlag("stripExif"),
           options.optionFlag("stripGps"),
+          options.optionQuality(),
           options.optionDouble("gpsLatitude"),
           options.optionDouble("gpsLongitude")
         )

--- a/android/src/test/java/com/simpleheic2jpg/CopyExifTest.kt
+++ b/android/src/test/java/com/simpleheic2jpg/CopyExifTest.kt
@@ -46,8 +46,8 @@ class CopyExifTest {
     val exif = ExifInterface(src.absolutePath)
     exif.setAttribute(ExifInterface.TAG_MAKE, "TestMake")
     exif.setAttribute(ExifInterface.TAG_MODEL, "TestModel")
-    // TAG_SOFTWARE is one of the tags added to the whitelist in P0; an IFD0 string,
-    // so it round-trips reliably and proves the expanded whitelist is honored.
+    // TAG_SOFTWARE is a whitelisted IFD0 string, so it round-trips reliably and
+    // proves the whitelist is honored.
     exif.setAttribute(ExifInterface.TAG_SOFTWARE, "UnitTestSoftware")
     exif.setAttribute(
       ExifInterface.TAG_ORIENTATION,

--- a/android/src/test/java/com/simpleheic2jpg/QualityOptionTest.kt
+++ b/android/src/test/java/com/simpleheic2jpg/QualityOptionTest.kt
@@ -1,0 +1,66 @@
+package com.simpleheic2jpg
+
+import com.facebook.react.bridge.ReadableMap
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Covers the native side of the quality option: the double→int marshalling, the 0–100 clamp,
+ * the rounding (not truncation) of fractional values, and the 80 fallback for direct native
+ * callers that omit the key. The JS wrapper normalizes quality before it ever reaches native,
+ * so these paths only fire for direct-native callers — but they are the native contract, so
+ * they are pinned here rather than left to the JS-layer tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class QualityOptionTest {
+
+  private fun mapWithQuality(value: Double): ReadableMap {
+    val map = Mockito.mock(ReadableMap::class.java)
+    Mockito.`when`(map.hasKey("quality")).thenReturn(true)
+    Mockito.`when`(map.isNull("quality")).thenReturn(false)
+    Mockito.`when`(map.getDouble("quality")).thenReturn(value)
+    return map
+  }
+
+  // optionQuality is an internal member extension on the object, so it must be invoked
+  // inside the object's scope.
+  private fun ReadableMap?.quality(): Int =
+    SimpleHeic2jpgModuleImpl.run { this@quality.optionQuality() }
+
+  @Test
+  fun defaultsTo80WhenMapIsNull() {
+    assertEquals(80, (null as ReadableMap?).quality())
+  }
+
+  @Test
+  fun defaultsTo80WhenKeyAbsent() {
+    val map = Mockito.mock(ReadableMap::class.java)
+    Mockito.`when`(map.hasKey("quality")).thenReturn(false)
+    assertEquals(80, map.quality())
+  }
+
+  @Test
+  fun forwardsAnIntegralValue() {
+    assertEquals(60, mapWithQuality(60.0).quality())
+  }
+
+  @Test
+  fun clampsAbove100() {
+    assertEquals(100, mapWithQuality(150.0).quality())
+  }
+
+  @Test
+  fun clampsBelow0() {
+    assertEquals(0, mapWithQuality(-10.0).quality())
+  }
+
+  @Test
+  fun roundsFractionalValue() {
+    assertEquals(73, mapWithQuality(72.6).quality())
+  }
+}

--- a/ios/SimpleHeic2jpg.mm
+++ b/ios/SimpleHeic2jpg.mm
@@ -20,6 +20,7 @@ RCT_EXPORT_MODULE(SimpleHeic2jpg)
   [self convertImageAtPathImplementation:path
                                stripExif:options.stripExif()
                                 stripGps:options.stripGps()
+                                 quality:options.quality()
                              gpsLatitude:lat.has_value() ? @(lat.value()) : nil
                             gpsLongitude:lng.has_value() ? @(lng.value()) : nil
                                  resolve:resolve
@@ -35,6 +36,7 @@ RCT_EXPORT_MODULE(SimpleHeic2jpg)
   [self convertImageAtPathAsBase64Implementation:path
                                        stripExif:options.stripExif()
                                         stripGps:options.stripGps()
+                                         quality:options.quality()
                                      gpsLatitude:lat.has_value() ? @(lat.value()) : nil
                                     gpsLongitude:lng.has_value() ? @(lng.value()) : nil
                                          resolve:resolve
@@ -53,6 +55,15 @@ static NSNumber *SHJOptionalNumber(NSDictionary *options, NSString *key) {
   return [value isKindOfClass:[NSNumber class]] ? (NSNumber *)value : nil;
 }
 
+// Old Architecture reads an untyped NSDictionary, so a direct native caller may omit
+// "quality"; default to 80 to match the JS wrapper. The New Architecture path reads the
+// typed, non-optional codegen field via options.quality(), which the JS wrapper always
+// fills — a direct caller that omits it there gets 0, not this default.
+static double SHJQuality(NSDictionary *options) {
+  id value = options[@"quality"];
+  return [value isKindOfClass:[NSNumber class]] ? [(NSNumber *)value doubleValue] : 80;
+}
+
 RCT_EXPORT_METHOD(convertImageAtPath:(NSString *)path
                   options:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
@@ -60,6 +71,7 @@ RCT_EXPORT_METHOD(convertImageAtPath:(NSString *)path
   [self convertImageAtPathImplementation:path
                                stripExif:[options[@"stripExif"] boolValue]
                                 stripGps:[options[@"stripGps"] boolValue]
+                                 quality:SHJQuality(options)
                              gpsLatitude:SHJOptionalNumber(options, @"gpsLatitude")
                             gpsLongitude:SHJOptionalNumber(options, @"gpsLongitude")
                                  resolve:resolve
@@ -73,6 +85,7 @@ RCT_EXPORT_METHOD(convertImageAtPathAsBase64:(NSString *)path
   [self convertImageAtPathAsBase64Implementation:path
                                        stripExif:[options[@"stripExif"] boolValue]
                                         stripGps:[options[@"stripGps"] boolValue]
+                                         quality:SHJQuality(options)
                                      gpsLatitude:SHJOptionalNumber(options, @"gpsLatitude")
                                     gpsLongitude:SHJOptionalNumber(options, @"gpsLongitude")
                                          resolve:resolve
@@ -84,6 +97,7 @@ RCT_EXPORT_METHOD(convertImageAtPathAsBase64:(NSString *)path
 - (void)convertImageAtPathImplementation:(NSString *)path
                                stripExif:(BOOL)stripExif
                                 stripGps:(BOOL)stripGps
+                                 quality:(double)quality
                              gpsLatitude:(NSNumber *)gpsLatitude
                             gpsLongitude:(NSNumber *)gpsLongitude
                                  resolve:(RCTPromiseResolveBlock)resolve
@@ -135,9 +149,14 @@ RCT_EXPORT_METHOD(convertImageAtPathAsBase64:(NSString *)path
 
       CIImage *ciImage = [CIImage imageWithCGImage:cgImage];
       CIContext *context = [CIContext context];
+      // kCGImageDestinationLossyCompressionQuality takes 0.0–1.0; the public API
+      // uses 0–100, so scale here. HEIC→JPEG is the only re-encode path.
+      NSDictionary *jpegOptions = @{
+        (__bridge NSString *)kCGImageDestinationLossyCompressionQuality: @(quality / 100.0)
+      };
       NSData *jpegData = [context JPEGRepresentationOfImage:ciImage
                                                  colorSpace:colorSpace
-                                                    options:@{}];
+                                                    options:jpegOptions];
       if (!jpegData) {
         reject(@"Image Conversion Failed", @"Image conversion to JPEG representation failed", nil);
         return;
@@ -196,6 +215,7 @@ RCT_EXPORT_METHOD(convertImageAtPathAsBase64:(NSString *)path
 - (void)convertImageAtPathAsBase64Implementation:(NSString *)path
                                        stripExif:(BOOL)stripExif
                                         stripGps:(BOOL)stripGps
+                                         quality:(double)quality
                                      gpsLatitude:(NSNumber *)gpsLatitude
                                     gpsLongitude:(NSNumber *)gpsLongitude
                                         resolve:(RCTPromiseResolveBlock)resolve
@@ -249,9 +269,14 @@ RCT_EXPORT_METHOD(convertImageAtPathAsBase64:(NSString *)path
 
       CIImage *ciImage = [CIImage imageWithCGImage:cgImage];
       CIContext *context = [CIContext context];
+      // Same 0–100 → 0.0–1.0 scaling as the URI path; writeFinalizedJPEGData below
+      // copies these encoded bytes without re-encoding, so quality is set here.
+      NSDictionary *jpegOptions = @{
+        (__bridge NSString *)kCGImageDestinationLossyCompressionQuality: @(quality / 100.0)
+      };
       NSData *jpegData = [context JPEGRepresentationOfImage:ciImage
                                                  colorSpace:colorSpace
-                                                    options:@{}];
+                                                    options:jpegOptions];
       if (!jpegData) {
         reject(@"Image Conversion Failed", @"Image conversion to JPEG representation failed", nil);
         return;

--- a/ios/generated/ReactCodegen/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpec.h
+++ b/ios/generated/ReactCodegen/RNSimpleHeic2jpgSpec/RNSimpleHeic2jpgSpec.h
@@ -37,6 +37,7 @@ namespace JS {
     struct ConvertNativeOptions {
       bool stripExif() const;
       bool stripGps() const;
+      double quality() const;
       std::optional<double> gpsLatitude() const;
       std::optional<double> gpsLongitude() const;
 
@@ -90,6 +91,11 @@ inline bool JS::NativeSimpleHeic2jpg::ConvertNativeOptions::stripGps() const
 {
   id const p = _v[@"stripGps"];
   return RCTBridgingToBool(p);
+}
+inline double JS::NativeSimpleHeic2jpg::ConvertNativeOptions::quality() const
+{
+  id const p = _v[@"quality"];
+  return RCTBridgingToDouble(p);
 }
 inline std::optional<double> JS::NativeSimpleHeic2jpg::ConvertNativeOptions::gpsLatitude() const
 {

--- a/ios/generated/ReactCodegen/RNSimpleHeic2jpgSpecJSI.h
+++ b/ios/generated/ReactCodegen/RNSimpleHeic2jpgSpecJSI.h
@@ -17,14 +17,15 @@ namespace facebook::react {
 
 #pragma mark - NativeSimpleHeic2jpgConvertNativeOptions
 
-template <typename P0, typename P1, typename P2, typename P3>
+template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct NativeSimpleHeic2jpgConvertNativeOptions {
   P0 stripExif{};
   P1 stripGps{};
-  P2 gpsLatitude{};
-  P3 gpsLongitude;
+  P2 quality{};
+  P3 gpsLatitude{};
+  P4 gpsLongitude;
   bool operator==(const NativeSimpleHeic2jpgConvertNativeOptions &other) const {
-    return stripExif == other.stripExif && stripGps == other.stripGps && gpsLatitude == other.gpsLatitude && gpsLongitude == other.gpsLongitude;
+    return stripExif == other.stripExif && stripGps == other.stripGps && quality == other.quality && gpsLatitude == other.gpsLatitude && gpsLongitude == other.gpsLongitude;
   }
 };
 
@@ -39,6 +40,7 @@ struct NativeSimpleHeic2jpgConvertNativeOptionsBridging {
     T result{
       bridging::fromJs<decltype(types.stripExif)>(rt, value.getProperty(rt, "stripExif"), jsInvoker),
       bridging::fromJs<decltype(types.stripGps)>(rt, value.getProperty(rt, "stripGps"), jsInvoker),
+      bridging::fromJs<decltype(types.quality)>(rt, value.getProperty(rt, "quality"), jsInvoker),
       bridging::fromJs<decltype(types.gpsLatitude)>(rt, value.getProperty(rt, "gpsLatitude"), jsInvoker),
       bridging::fromJs<decltype(types.gpsLongitude)>(rt, value.getProperty(rt, "gpsLongitude"), jsInvoker)};
     return result;
@@ -49,6 +51,9 @@ struct NativeSimpleHeic2jpgConvertNativeOptionsBridging {
     return bridging::toJs(rt, value);
   }
   static bool stripGpsToJs(jsi::Runtime &rt, decltype(types.stripGps) value) {
+    return bridging::toJs(rt, value);
+  }
+  static double qualityToJs(jsi::Runtime &rt, decltype(types.quality) value) {
     return bridging::toJs(rt, value);
   }
   static double gpsLatitudeToJs(jsi::Runtime &rt, decltype(types.gpsLatitude) value) {
@@ -66,6 +71,7 @@ struct NativeSimpleHeic2jpgConvertNativeOptionsBridging {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, "stripExif", bridging::toJs(rt, value.stripExif, jsInvoker));
     result.setProperty(rt, "stripGps", bridging::toJs(rt, value.stripGps, jsInvoker));
+    result.setProperty(rt, "quality", bridging::toJs(rt, value.quality, jsInvoker));
     if (value.gpsLatitude) {
       result.setProperty(rt, "gpsLatitude", bridging::toJs(rt, value.gpsLatitude.value(), jsInvoker));
     }

--- a/src/NativeSimpleHeic2jpg.ts
+++ b/src/NativeSimpleHeic2jpg.ts
@@ -8,6 +8,11 @@ import { TurboModuleRegistry, NativeModules } from 'react-native';
 export type ConvertNativeOptions = {
   stripExif: boolean;
   stripGps: boolean;
+  // JPEG encode quality for HEIC/HEIF → JPEG conversions, as an integer 0–100.
+  // Non-optional: the public API (src/index.tsx) always fills a default before
+  // crossing the boundary, so native never has to guess. Ignored for JPEG/PNG
+  // pass-through inputs, which are not re-encoded.
+  quality: number;
   // Optional GPS injection: when both are present, the converted JPEG's GPS
   // EXIF is written from these values (overriding stripGps for the GPS block).
   // Optional (not defaulted) because absence — not a sentinel — means "do not inject".

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -34,6 +34,7 @@ describe('convertImage', () => {
     expect(mockConvertImageAtPath).toHaveBeenCalledWith('/tmp/input.heic', {
       stripExif: false,
       stripGps: false,
+      quality: 80,
     });
     expect(mockConvertImageAtPathAsBase64).not.toHaveBeenCalled();
   });
@@ -54,7 +55,7 @@ describe('convertImage', () => {
     ).resolves.toBe('abc123+/=');
     expect(mockConvertImageAtPathAsBase64).toHaveBeenCalledWith(
       '/tmp/input.heic',
-      { stripExif: false, stripGps: false }
+      { stripExif: false, stripGps: false, quality: 80 }
     );
     expect(mockConvertImageAtPath).not.toHaveBeenCalled();
   });
@@ -66,6 +67,7 @@ describe('convertImage', () => {
     expect(mockConvertImageAtPath).toHaveBeenCalledWith('/tmp/input.heic', {
       stripExif: false,
       stripGps: true,
+      quality: 80,
     });
   });
 
@@ -78,6 +80,7 @@ describe('convertImage', () => {
     expect(mockConvertImageAtPath).toHaveBeenCalledWith('/tmp/input.heic', {
       stripExif: false,
       stripGps: false,
+      quality: 80,
       gpsLatitude: 35.1796,
       gpsLongitude: 129.0756,
     });
@@ -95,6 +98,7 @@ describe('convertImage', () => {
       {
         stripExif: false,
         stripGps: false,
+        quality: 80,
         gpsLatitude: -33.8688,
         gpsLongitude: 151.2093,
       }
@@ -166,5 +170,44 @@ describe('convertImage', () => {
     await expect(
       convertImage('/tmp/input.heic', { returnBase64: true })
     ).rejects.toBe(nativeError);
+  });
+
+  it('forwards an explicit quality to native', async () => {
+    mockConvertImageAtPath?.mockResolvedValue('file:///tmp/output.jpeg');
+
+    await convertImage('/tmp/input.heic', { quality: 60 });
+    expect(mockConvertImageAtPath).toHaveBeenCalledWith('/tmp/input.heic', {
+      stripExif: false,
+      stripGps: false,
+      quality: 60,
+    });
+  });
+
+  it('clamps quality above 100 down to 100', async () => {
+    mockConvertImageAtPath?.mockResolvedValue('file:///tmp/output.jpeg');
+
+    await convertImage('/tmp/input.heic', { quality: 150 });
+    expect(mockConvertImageAtPath?.mock.calls[0]?.[1]?.quality).toBe(100);
+  });
+
+  it('clamps negative quality up to 0', async () => {
+    mockConvertImageAtPath?.mockResolvedValue('file:///tmp/output.jpeg');
+
+    await convertImage('/tmp/input.heic', { quality: -10 });
+    expect(mockConvertImageAtPath?.mock.calls[0]?.[1]?.quality).toBe(0);
+  });
+
+  it('rounds a fractional quality to an integer', async () => {
+    mockConvertImageAtPath?.mockResolvedValue('file:///tmp/output.jpeg');
+
+    await convertImage('/tmp/input.heic', { quality: 72.6 });
+    expect(mockConvertImageAtPath?.mock.calls[0]?.[1]?.quality).toBe(73);
+  });
+
+  it('throws when quality is not a number', async () => {
+    await expect(
+      // @ts-expect-error exercising a runtime guard against bad input
+      convertImage('/tmp/input.heic', { quality: 'high' })
+    ).rejects.toThrow('quality must be a number between 0 and 100');
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,13 @@ export type ConvertImageOptions = {
   stripExif?: boolean;
   stripGps?: boolean;
   /**
+   * JPEG encode quality as an integer 0–100. Defaults to 80. Only applies to
+   * HEIC/HEIF inputs, which are re-encoded to JPEG; JPEG and PNG inputs pass
+   * through without re-encoding, so this option has no effect on them. Values
+   * are clamped to the 0–100 range and rounded to an integer.
+   */
+  quality?: number;
+  /**
    * Write these GPS coordinates into the output, replacing whatever the source
    * carried (and overriding stripGps/stripExif for the GPS block). HEIC inputs get
    * them on the converted JPEG; JPEG inputs are promoted from pass-through to an
@@ -15,6 +22,24 @@ export type ConvertImageOptions = {
    */
   gps?: { latitude: number; longitude: number };
 };
+
+// The public default JPEG quality. The native sides carry their own copy of this
+// value as a defensive fallback for direct native callers (ios/SimpleHeic2jpg.mm
+// SHJQuality, android SimpleHeic2jpgModuleImpl.optionQuality); keep the three in sync.
+const DEFAULT_QUALITY = 80;
+
+// Coerce the public quality option into the bounded integer the native encoders
+// expect. Absence means "use the default"; a non-number is a caller mistake and
+// throws; anything in between is clamped to 0–100 and rounded.
+function normalizeQuality(quality: number | undefined): number {
+  if (quality === undefined) {
+    return DEFAULT_QUALITY;
+  }
+  if (typeof quality !== 'number' || Number.isNaN(quality)) {
+    throw new Error('convertImage: quality must be a number between 0 and 100');
+  }
+  return Math.round(Math.min(100, Math.max(0, quality)));
+}
 
 async function convertImage(
   imagePath: string,
@@ -29,6 +54,7 @@ async function convertImage(
   const nativeOptions: ConvertNativeOptions = {
     stripExif: options?.stripExif ?? false,
     stripGps: options?.stripGps ?? false,
+    quality: normalizeQuality(options?.quality),
   };
   if (options?.gps) {
     nativeOptions.gpsLatitude = options.gps.latitude;


### PR DESCRIPTION
## Summary

Adds a `quality` option to `convertImage`, resolving #10. Previously the JPEG encode quality was fixed, producing needlessly large files.

- New option: `quality?: number` — an integer `0`–`100`, default `80`. Out-of-range values are clamped; fractional values are rounded.
- Threaded through every layer: TypeScript wrapper → codegen spec → iOS (`CIContext` JPEG encode via `kCGImageDestinationLossyCompressionQuality`) → Android (`Bitmap.compress`).
- Applies only to the HEIC/HEIF re-encode path. JPEG and PNG inputs pass through without re-encoding, so `quality` has no effect on them (documented).

## Behavior change

The default output size changes. Android previously encoded at an effective quality of `100` and iOS used the system default; both now default to `80`, so converted JPEGs are noticeably smaller. Callers who need the previous maximum-quality output can pass `quality: 100`.

## Test plan

- [x] `yarn test` — 19/19 pass, including new cases: explicit quality forwarding, clamp above 100, clamp below 0, fractional rounding, and non-number rejection.
- [x] `yarn typecheck` — clean.
- [x] `yarn lint` — clean.
- [x] `yarn prepare` — codegen regenerated; tracked `ios/generated` / `android/generated` updated and consistent with the spec.
- [x] Added `QualityOptionTest.kt` covering the Android native clamp/round/default path (mirrors the existing Robolectric + Mockito unit tests; runs under the example-app/CI Gradle build).
- [x] Manual device verification of output file-size reduction on iOS and Android.

## Notes

- Comment-only cleanup in a separate commit removes stale internal planning notes from the earlier EXIF work.
- Follow-up options considered but intentionally deferred to a separate branch: max width/height resize, EXIF-orientation normalization, and returning output dimensions/size.
