### PR TITLE
fix(ios): strip EXIF/GPS via kCFNull sentinel

### DIFF
--- a/ios/SimpleHeic2jpg.mm
+++ b/ios/SimpleHeic2jpg.mm
@@ -441,9 +441,12 @@ RCT_EXPORT_METHOD(convertImageAtPathAsBase64:(NSString *)path
       if (strippedProperties) {
         // Either flag removes GPS; stripExif additionally removes the EXIF block.
         // Orientation is untouched (it lives in the TIFF/top-level dicts).
-        CFDictionaryRemoveValue(strippedProperties, kCGImagePropertyGPSDictionary);
+        // Must set kCFNull rather than remove the key: CGImageDestinationAddImageFromSource
+        // MERGES these properties onto the source image's metadata, so a removed key falls
+        // back to the source value. kCFNull is the ImageIO sentinel that actually strips it.
+        CFDictionarySetValue(strippedProperties, kCGImagePropertyGPSDictionary, kCFNull);
         if (stripExif) {
-          CFDictionaryRemoveValue(strippedProperties, kCGImagePropertyExifDictionary);
+          CFDictionarySetValue(strippedProperties, kCGImagePropertyExifDictionary, kCFNull);
         }
         propertiesToWrite = strippedProperties;
       }

--- a/ios/Tests/SimpleHeic2jpgStripTests.m
+++ b/ios/Tests/SimpleHeic2jpgStripTests.m
@@ -169,8 +169,14 @@ static NSDictionary *PropertiesOfData(NSData *data) {
 
 - (void)testStripExifRemovesExifAndGpsKeepsOrientation {
   NSDictionary *props = [self writeWithStripExif:YES stripGps:NO];
-  XCTAssertNil(props[(id)kCGImagePropertyExifDictionary],
-               @"EXIF dictionary should be removed by stripExif");
+  // ImageIO re-synthesizes a minimal EXIF dict (ColorSpace + PixelXDimension/
+  // PixelYDimension) for every JPEG it encodes, so the dict itself cannot be made nil via
+  // CGImageDestination. What stripExif must guarantee is that the source's own EXIF payload
+  // is gone: the fixture planted a UserComment, so assert that specific tag no longer
+  // survives (the synthesized dimension/colorspace baseline is allowed to remain).
+  NSDictionary *exif = props[(id)kCGImagePropertyExifDictionary];
+  XCTAssertNil(exif[(id)kCGImagePropertyExifUserComment],
+               @"source EXIF payload (UserComment) should be removed by stripExif");
   XCTAssertNil(props[(id)kCGImagePropertyGPSDictionary],
                @"stripExif implies GPS removal");
   XCTAssertNotNil(props[(id)kCGImagePropertyOrientation],


### PR DESCRIPTION
## What

Fixes iOS `stripExif` / `stripGps` not actually removing metadata.

`writeFinalizedJPEGData` stripped by calling `CFDictionaryRemoveValue` on the properties dictionary, then wrote via `CGImageDestinationAddImageFromSource`. That API **merges** the supplied properties onto the source image's existing metadata, so a *removed* key simply falls back to the source value — the original EXIF/GPS block survived. As a result `stripExif`/`stripGps` were no-ops on iOS.

Fix: set the dictionaries to `kCFNull` (the ImageIO sentinel that removes a block on write) instead of removing the keys. GPS injection was already correct because it used `CFDictionarySetValue` with a real dictionary.

## Test change

The strip test asserted the whole EXIF dictionary was `nil`, which is unsatisfiable on iOS: `CGImageDestination` always re-synthesizes a minimal EXIF dict (`ColorSpace` + `PixelXDimension`/`PixelYDimension`) for every JPEG. The assertion now checks the source EXIF payload (the fixture's `UserComment`) is gone, which is the privacy-relevant guarantee. Android can zero the whole block via `ExifInterface` — platform asymmetry.

## Verification

The iOS `test_spec` had never actually executed before (no CI, and the example Podfile autolinks the library without `:testspecs`, so no test target is generated; the target also fails to link libc++ since the test source is pure ObjC while the SUT is C++).

Ran locally against an iPhone 17 Pro simulator (Xcode 26.4) by temporarily opting the example Podfile into `:testspecs` and passing `-lc++`:

- iOS XCTest: **4/4 pass** (was 3 failing before the fix)
- Android unit tests: **14/14 pass**
- JS (Jest): **19/19 pass**, typecheck + lint clean

## Follow-up (not in this PR)

Wire the iOS `test_spec` to link libc++ (`pod_target_xcconfig`) and add a CI job running `xcodebuild test`, so iOS regressions like this are caught automatically.